### PR TITLE
AvailabilityZones help change to 2 AZs

### DIFF
--- a/templates/starrocks-entrypoint-new-vpc.template.yaml
+++ b/templates/starrocks-entrypoint-new-vpc.template.yaml
@@ -145,8 +145,7 @@ Metadata:
         default: Default syslog directory
 Parameters:
   AvailabilityZones:
-    Description: List of Availability Zones to use for the subnets in the VPC. Three
-      Availability Zones are used for this deployment.
+    Description: List of Availability Zones to use for the subnets in the VPC. Two Availability Zones are used in this deployment.
     Type: List<AWS::EC2::AvailabilityZone::Name>
   KeyPairName:
     Type: AWS::EC2::KeyPair::KeyName


### PR DESCRIPTION
Changed help for AvailabilityZones parameter to indicate that he deployment uses 2 AZs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
